### PR TITLE
fix Tampermonkey spelling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 보안 관련 수정 내역
 
+## [0.1.1] – 2025-08-08
+
+### Fixed
+
+- Corrected "Tampermonkey" spelling in README
+
 ## [0.1.0] – 2025-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📌 YouTube Comment Blocker by Handle — v0.1.0
+# 📌 YouTube Comment Blocker by Handle — v0.1.1
 
 Tampermonkey에서 동작하는 사용자 스크립트로, **YouTube 댓글에서 특정 사용자 핸들(@handle)을 차단**할 수 있습니다.
 차단된 사용자의 댓글은 실시간으로 숨겨지며, 차단 목록은 **메뉴로 관리/가져오기/내보내기** 할 수 있습니다.
@@ -29,7 +29,7 @@ Tampermonkey에서 동작하는 사용자 스크립트로, **YouTube 댓글에�
 3. YouTube 페이지 접속 후, 댓글 영역에서 다음 사용 가능:
 
    * 작성자 핸들 우클릭 → 차단/해제 팝업
-   * 핸들이 아닌 곳에서 우클릭 → Tampermonky → YouTube Comment Blocker by Handle → 차단 목록 관리 / 초기화
+   * 핸들이 아닌 곳에서 우클릭 → Tampermonkey → YouTube Comment Blocker by Handle → 차단 목록 관리 / 초기화
 
 ---
 

--- a/ytblockhandlecomments.js
+++ b/ytblockhandlecomments.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         YouTube Comment Blocker by Handle
 // @namespace    http://tampermonkey.net/
-// @version      0.1.0
+// @version      0.1.1
 // @description  댓글 핸들 우클릭으로 차단/해제. 실시간 숨김, 커스텀 팝업, 토스트 알림, 차단 목록 관리/가져오기/내보내기 지원.
 // @author       Mango_Clark
 // @match        https://www.youtube.com/*


### PR DESCRIPTION
## Summary
- correct Tampermonkey spelling in README
- bump version to 0.1.1 and update changelog

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68960d8ffb8c83208fd6ab796e629dcf