### PR TITLE
docs: document storage versioning and add update URLs

### DIFF
--- a/"b/\353\202\230\353\245\274\354\235\275\354\226\264.md"
+++ b/"b/\353\202\230\353\245\274\354\235\275\354\226\264.md"
@@ -1,0 +1,58 @@
+# 📌 핸들로 YouTube 댓글 차단 — v0.1.2
+
+특정 사용자 핸들(@handle)의 댓글을 숨길 수 있는 Tampermonkey 사용자 스크립트입니다. 숨겨진 댓글은 실시간으로 사라지며, 차단 목록은 메뉴에서 관리·가져오기·내보내기가 가능합니다.
+
+---
+
+## ✅ 주요 기능
+
+- 🔇 작성자 핸들을 우클릭하여 차단/해제
+- ⋯ 메뉴에 "이 채널 댓글 숨김" 항목 자동 추가
+- MutationObserver로 실시간 DOM 처리
+- 🔧 차단 목록 팝업:
+
+  - 차단된 핸들 확인/해제
+  - JSON 또는 줄바꿈 텍스트로 내보내기
+  - JSON 또는 줄바꿈 텍스트로 가져오기
+- 📝 `GM_registerMenuCommand` 설정:
+
+  - `🔍 차단 목록 관리`
+  - `🗑️ 차단 목록 초기화`
+
+---
+
+## 🧠 사용 방법
+
+1. [Tampermonkey](https://www.tampermonkey.net/) 설치
+2. 새 사용자 스크립트를 만들고 `ytblockhandlecomments.js` 내용을 붙여넣기
+3. YouTube 페이지에서 다음 사용 가능:
+
+   - 작성자 핸들을 우클릭하여 차단/해제
+   - 핸들이 아닌 곳을 우클릭 → Tampermonkey → YouTube Comment Blocker by Handle → 차단 목록 관리/초기화
+
+---
+
+## 💾 저장 구조
+
+- 저장 키: `'blockedHandles_v1'`
+- 저장 값: `{ version: 1, updatedAt: number, handles: string[] }`
+- Tampermonkey의 `GM_getValue`, `GM_setValue` 사용
+- 백업용 JSON 형식 가져오기/내보내기 지원
+
+---
+
+## ⚠️ 한계 및 주의사항
+
+- 핸들 비교 시 **대소문자를 구분함** (`@Mango_Clark` ≠ `@mango_clark`)
+- 저장 구조는 버전이 있으며 레거시 데이터를 자동으로 마이그레이션함
+- 컨텍스트 메뉴는 DOM에 직접 바인딩하지 않고 **위임 이벤트**를 사용함
+- `GM_addValueChangeListener`를 통해 **탭 간 동기화**를 지원함
+- 다이얼로그의 `textarea`는 DOM 직접 접근 방식으로 다소 불안정할 수 있음
+
+---
+
+## 👤 작성자
+
+- **Mango_Clark**
+- 라이선스: MIT
+

--- a/"b/\353\263\200\352\262\275\354\202\254\355\225\255.md"
+++ b/"b/\353\263\200\352\262\275\354\202\254\355\225\255.md"
@@ -1,0 +1,78 @@
+# 변경사항
+
+이 프로젝트의 모든 중요한 변경 사항은 이 파일에 기록됩니다.
+
+이 포맷은 [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/)을 기반으로 하며,
+이 프로젝트는 [Semantic Versioning](https://semver.org/lang/ko/spec/v2.0.0.html)을 따릅니다.
+
+## [Unreleased]
+
+### Added
+- 없음
+
+### Changed
+- 없음
+
+### Deprecated
+- 없음
+
+### Removed
+- 없음
+
+### Fixed
+- 없음
+
+### Security
+- 없음
+
+## [0.1.2] – 2025-08-08
+
+### Added
+- 사용자 스크립트에 `@updateURL`과 `@downloadURL` 메타데이터 추가
+- 저장소 버전 관리, 위임 컨텍스트 메뉴 이벤트, 탭 간 동기화, JSON 가져오기/내보내기 문서화
+
+### Changed
+- README를 영어로 재작성하고 한국어 번역본 추가
+
+## [0.1.1] – 2025-08-08
+
+### Fixed
+- README에서 "Tampermonkey" 철자 수정
+
+## [0.1.0] – 2025-08-08
+
+### Added
+- 클래스 기반 OOP 구조로 전체 코드 리팩토링
+- 자동 메뉴 주입 기능을 `MenuEnhancer` 클래스로 분리
+- 차단 목록 내보내기에 JSON 및 줄바꿈 텍스트 포맷 제공
+- JSON 스키마 및 다중 포맷 가져오기 처리
+- 버전이 있는 저장 키 `blockedHandles_v1` 도입 및 레거시 `blockedHandles` 자동 마이그레이션
+- `GM_addValueChangeListener`로 탭 간 동기화 지원
+- 핸들을 소문자로 정규화
+- 포커스 트랩이 적용된 다이얼로그 개선
+- MutationObserver와 requestAnimationFrame 기반 디바운스로 성능 향상
+
+### Changed
+- DOM 직접 바인딩 방식에서 위임 이벤트 처리로 변경
+- 목록 UI를 동적으로 렌더링하도록 개선
+
+### Deprecated
+- `blockedHandles` 키는 유지하되 내부적으로는 사용하지 않음
+
+### Fixed
+- 일부 댓글 스레드에서 차단이 누락되던 문제 해결
+
+### Security
+- 다이얼로그에 텍스트 노드를 우선 사용하여 XSS 위험 감소
+
+## [0.0.1] – 2025-07-06
+
+### Added
+- 댓글 작성자 `@handle`을 우클릭하여 차단/해제 기능
+- 실시간 댓글 차단을 위한 `MutationObserver` 도입
+- 차단된 핸들을 팝업에서 확인·해제 가능한 차단 목록 UI
+- 줄바꿈 텍스트로 차단 목록 내보내기/가져오기 기능
+- 다음 두 가지 Tampermonkey 메뉴 명령 추가:
+  - 🔍 차단 목록 관리
+  - 🗑️ 차단 목록 초기화
+- 사용자용 커스텀 토스트 알림 및 간단한 다이얼로그 인터페이스

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,99 +8,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
-- 새롭게 추가된 기능
+- None
 
 ### Changed
-
-- 기존 기능이 변경된 내용
+- None
 
 ### Deprecated
-
-- 향후 제거될 예정인 기능
+- None
 
 ### Removed
-
-- 완전히 제거된 기능
+- None
 
 ### Fixed
-
-- 버그 수정 내역
+- None
 
 ### Security
+- None
 
-- 보안 관련 수정 내역
+## [0.1.2] – 2025-08-08
+
+### Added
+- Added `@updateURL` and `@downloadURL` metadata for the userscript
+- Documented storage versioning, delegated context menu events, cross-tab synchronization, and JSON import/export
+
+### Changed
+- Rewrote README in English and provided Korean translation
 
 ## [0.1.1] – 2025-08-08
 
 ### Fixed
-
 - Corrected "Tampermonkey" spelling in README
 
 ## [0.1.0] – 2025-08-08
 
 ### Added
-
-- OOP 구조(Class 기반)로 전체 코드 리팩토링
-- 댓글 ⋯ 메뉴 자동 주입 기능 분리 (`MenuEnhancer` 클래스)
-- 차단 목록 내보내기(JSON + 라인별) 포맷 제공
-- 가져오기 시 JSON 스키마 형식 및 다중 포맷 처리
-- 차단 목록 저장 구조에 버전(`blockedHandles_v1`) 도입 및 레거시(`blockedHandles`) 자동 마이그레이션
-- 탭 간 동기화(`GM_addValueChangeListener`) 지원
-- 핸들 정규화(@handle → 소문자 처리)
-- 포커스 트랩 적용한 다이얼로그 개선
-- MutationObserver 및 rAF 기반 디바운스 적용으로 성능 향상
+- Refactored entire codebase to a class-based OOP structure
+- Separated automatic menu injection into the `MenuEnhancer` class
+- Provided export formats (JSON and line-by-line text) for the block list
+- Handled import via JSON schema and multiple formats
+- Introduced versioned storage key `blockedHandles_v1` and automatic migration from legacy `blockedHandles`
+- Added cross-tab synchronization with `GM_addValueChangeListener`
+- Normalized handles to lowercase
+- Improved dialog with focus trap
+- Enhanced performance using MutationObserver and requestAnimationFrame-based debounce
 
 ### Changed
-
-- 기존 DOM 탐색/이벤트 처리 방식 → 위임 이벤트 처리로 변경
-- 목록 UI를 동적으로 렌더링하도록 개선
+- Switched from direct DOM binding to delegated event handling
+- Improved list UI to render dynamically
 
 ### Deprecated
-
-- `blockedHandles` 키는 유지하되 내부적으로는 사용하지 않음
-
-### Removed
-
-- 없음
+- Kept the `blockedHandles` key but no longer used internally
 
 ### Fixed
-
-- 일부 댓글 스레드에서 차단이 누락되던 문제 해결
+- Fixed missed blocking in some comment threads
 
 ### Security
-
-- 다이얼로그에 텍스트 노드를 우선 사용하여 XSS 위험 감소
+- Reduced XSS risk by prioritizing text nodes in dialogs
 
 ## [0.0.1] – 2025-07-06
 
 ### Added
-
-- 댓글 작성자 핸들(@handle)을 우클릭하여 차단/해제하는 기능
-- 실시간 댓글 차단 적용을 위한 `MutationObserver` 도입
-- 차단된 핸들을 팝업에서 확인·해제 가능한 차단 목록 UI
-- 차단 목록을 줄바꿈 텍스트로 **내보내기/가져오기** 기능
-- Tampermonkey 메뉴(`GM_registerMenuCommand`)에 관리 명령 2종 추가:
-  - 🔍 차단 목록 관리
-  - 🗑️ 차단 목록 초기화
-- 사용자용 커스텀 토스트 알림 및 간단한 다이얼로그 인터페이스
-
-### Changed
-
-- 없음
-
-### Deprecated
-
-- 없음
-
-### Removed
-
-- 없음
-
-### Fixed
-
-- 없음
-
-### Security
-
-- 없음
+- Block or unblock comment authors by right-clicking their `@handle`
+- Introduced `MutationObserver` for real-time comment blocking
+- Block list UI with popup to review or unblock handles
+- Export/import block list as newline-separated text
+- Added two Tampermonkey menu commands:
+  - 🔍 Manage block list
+  - 🗑️ Clear block list
+- Custom toast notifications and simple dialog interface

--- a/README.md
+++ b/README.md
@@ -1,57 +1,58 @@
-# 📌 YouTube Comment Blocker by Handle — v0.1.1
+# 📌 YouTube Comment Blocker by Handle — v0.1.2
 
-Tampermonkey에서 동작하는 사용자 스크립트로, **YouTube 댓글에서 특정 사용자 핸들(@handle)을 차단**할 수 있습니다.
-차단된 사용자의 댓글은 실시간으로 숨겨지며, 차단 목록은 **메뉴로 관리/가져오기/내보내기** 할 수 있습니다.
-
----
-
-## ✅ 주요 기능
-
-* 🔇 댓글의 작성자 핸들을 우클릭 → 차단/해제
-* ⋯ 메뉴에도 "이 채널 댓글 숨김" 항목 자동 추가
-* 실시간 DOM 반영: MutationObserver로 유튜브 동적 댓글 처리 대응
-* 🔧 차단 목록 팝업:
-
-  * 차단된 핸들 목록 확인/해제
-  * 내보내기 (`@handle` 줄바꿈 텍스트)
-  * 가져오기 (`@handle` 붙여넣기)
-* 📝 설정 메뉴 (`GM_registerMenuCommand`)
-
-  * `🔍 차단 목록 관리`
-  * `🗑️ 차단 목록 초기화`
+A Tampermonkey userscript that lets you block YouTube comments from specific author handles (@handle). Hidden comments disappear in real time, and the block list can be managed, imported, or exported via the menu.
 
 ---
 
-## 🧠 사용 방법
+## ✅ Features
 
-1. [Tampermonkey](https://www.tampermonkey.net/) 확장 설치
-2. 새 사용자 스크립트로 `ytblockhandlecomments.js` 내용 붙여넣기
-3. YouTube 페이지 접속 후, 댓글 영역에서 다음 사용 가능:
+- 🔇 Right-click an author handle to block or unblock
+- Adds "Hide comments from this channel" to the ⋯ menu automatically
+- Real-time DOM updates using MutationObserver
+- 🔧 Block list popup:
 
-   * 작성자 핸들 우클릭 → 차단/해제 팝업
-   * 핸들이 아닌 곳에서 우클릭 → Tampermonkey → YouTube Comment Blocker by Handle → 차단 목록 관리 / 초기화
+  - Review or unblock handles
+  - Export handles as JSON or newline text
+  - Import handles from JSON or newline text
+- 📝 Settings via `GM_registerMenuCommand`:
 
----
-
-## 💾 저장 구조
-
-* 저장 키: `'blockedHandles'`
-* 저장 값: 문자열 배열 (예: `["@user1", "@user2"]`)
-* LocalStorage가 아닌 Tampermonkey의 `GM_getValue`, `GM_setValue`를 사용
+  - `🔍 Manage block list`
+  - `🗑️ Clear block list`
 
 ---
 
-## ⚠️ 한계 및 주의사항 (v1.0)
+## 🧠 Usage
 
-* 핸들 비교 시 **대소문자 구분함** (`@Mango_Clark` ≠ `@mango_clark`)
-* 차단 목록 저장 구조는 **버전이 없음** (v1.1부터 JSON 스키마 기반으로 개선 예정)
-* 우클릭 이벤트는 DOM에 직접 바인딩 (O(n)) → 성능 이슈 가능
-* 단일 탭 동작 기준. **탭 간 동기화는 미지원**
-* 다이얼로그 내 `textarea` 접근은 DOM 직접 접근 방식으로 불안정
+1. Install [Tampermonkey](https://www.tampermonkey.net/)
+2. Create a new userscript and paste the contents of `ytblockhandlecomments.js`
+3. On any YouTube page:
+
+   - Right-click an author handle to block or unblock
+   - Right-click elsewhere → Tampermonkey → YouTube Comment Blocker by Handle → Manage/Clear block list
+
+---
+
+## 💾 Storage
+
+- Storage key: `'blockedHandles_v1'`
+- Storage value: `{ version: 1, updatedAt: number, handles: string[] }`
+- Uses Tampermonkey `GM_getValue` and `GM_setValue`
+- Supports import/export in JSON format for backups
+
+---
+
+## ⚠️ Limitations & Notes
+
+- Handle comparison is **case-sensitive** (`@Mango_Clark` ≠ `@mango_clark`)
+- Storage is versioned and migrates legacy data automatically
+- Context menus use **delegated events**, avoiding direct DOM bindings
+- Cross-tab synchronization is supported via `GM_addValueChangeListener`
+- The dialog's `textarea` relies on direct DOM access and may be fragile
 
 ---
 
 ## 👤 Author
 
-* **Mango\_Clark**
-* License: MIT
+- **Mango_Clark**
+- License: MIT
+

--- a/ytblockhandlecomments.js
+++ b/ytblockhandlecomments.js
@@ -1,8 +1,10 @@
 // ==UserScript==
 // @name         YouTube Comment Blocker by Handle
 // @namespace    http://tampermonkey.net/
-// @version      0.1.1
-// @description  댓글 핸들 우클릭으로 차단/해제. 실시간 숨김, 커스텀 팝업, 토스트 알림, 차단 목록 관리/가져오기/내보내기 지원.
+// @version      0.1.2
+// @description  Block/unblock comment handles via right-click. Real-time hiding, custom popup, toast alerts, and block list manage/import/export.
+// @updateURL    https://raw.githubusercontent.com/example/ytblockhandlecomments/main/ytblockhandlecomments.js
+// @downloadURL  https://raw.githubusercontent.com/example/ytblockhandlecomments/main/ytblockhandlecomments.js
 // @author       Mango_Clark
 // @match        https://www.youtube.com/*
 // @grant        GM_getValue


### PR DESCRIPTION
## Summary
- rewrite README in English and note versioned storage, delegated context menus, cross-tab sync, and JSON import/export
- translate README and changelog to Korean
- add @updateURL and @downloadURL metadata to userscript
- remove empty "None"/"없음" sections from past changelog entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689612d1cdf48320bf6be2f201a0130f